### PR TITLE
CS-213 Fix/ArgoCD 설정 경로 변경

### DIFF
--- a/argocd/dev-user-service-application.yaml
+++ b/argocd/dev-user-service-application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dev-user-service
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/KEA-ChunSam/PlayUs-k8s.git
+    targetRevision: HEAD
+    path: overlays/develop/user-service
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: user-service
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd/user-db-secret-application.yaml
+++ b/argocd/user-db-secret-application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: user-db-secret
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/KEA-ChunSam/PlayUs-k8s.git
+    targetRevision: HEAD
+    path: overlays/develop/user-service/sealed-secret  # 새로 만든 디렉토리
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: user-service
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
- ArgoCD를 코드로 만들어 CLI를 통해 배포되도록 하였습니다

```
kubectl apply -f user-db-secret-application.yaml -n argocd
```
이러한 형식의 명령어를 통해 argocd에 애플리케이션이 배포됩니다

---

## 🔗 관련 이슈
- closes #27 

---

## 💡 추가 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - Argo CD를 통해 `dev-user-service`와 `user-db-secret` 애플리케이션이 추가되어 자동 배포 및 상태 복구가 지원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->